### PR TITLE
fix: pagination class not active

### DIFF
--- a/index.php
+++ b/index.php
@@ -183,7 +183,7 @@
                 <ul class="pager">
                     <?php
                     for ($i = 1; $i <= $count; $i++) {
-                        if ($i == $page) {
+                        if ($i == $page || $page == '' && $i == 1) {
                             echo "<li><a href='index.php?page={$i}' class='active'>{$i}</a></li>";
                         } else {
                             echo "<li><a href='index.php?page={$i}'>{$i}</a></li>";


### PR DESCRIPTION
I have fixed the bug, in the pagination section

Previously when only accessing the index.php url, without the $_GET['page'] variable, it would display something like this
![Screenshot from 2021-10-04 18-17-44](https://user-images.githubusercontent.com/60420319/135842468-c6512c98-85c7-4c61-9e42-05709dfaded0.png)

Then after I edit, even though I only access the index.php url, without the $_GET['page'] variable, the first pagination link will still be active as follows
![Screenshot from 2021-10-04 18-18-07](https://user-images.githubusercontent.com/60420319/135842496-289b40c7-627d-434c-bfcf-d02c9dfff242.png)

