### PR TITLE
Smooth Button Hover Effect 

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -168,7 +168,6 @@ a.icon-link:hover {
   color: #363738;
   font-weight: bold;
   outline: none;
-  box-shadow: 1px 1px 3px 0 rgba(0, 0, 0, 0.2);
   overflow: hidden;
   border-radius: 0;
   height: 50px;
@@ -176,6 +175,10 @@ a.icon-link:hover {
   display: inline-block;
   padding: 0;
   border: none;
+  box-shadow: inset 40px 0px 0px #ffb535;
+  display: block;
+  -webkit-transition: all 0.4s cubic-bezier(.5, .24, 0, 1);
+  transition: all 0.4s cubic-bezier(.5, .24, 0, 1);
 }
 
 .btn1:focus {
@@ -183,7 +186,7 @@ a.icon-link:hover {
 }
 
 .btn1:hover {
-  background: #ffb535;
+  box-shadow: inset 180px 0px 0px #ffb535;
   color: #fff;
 }
 


### PR DESCRIPTION
Modified the design of the **`Read More`** Btn.

Fixes: #45  

As per the things mentioned in the issue #45, I have done the required changes to the codebase.
A smooth transition is added for the `#ffb535` background to complete the btn-width.
It's working completely fine has no issue with the responsiveness of the UI.

GIF of the working component for reference:
![ReadMoreBtnGif](https://user-images.githubusercontent.com/63443481/135975569-e69e7256-bc32-48ba-ba78-9b908aa9db62.gif)

Have a look! 😃