### PR TITLE
Hotfix: missing session_start on "Contact" and "Register" pages

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -1,5 +1,10 @@
-<?php include "includes/db.php"; ?>
-<?php include "includes/header.php"; ?>
+<?php
+
+session_start();
+
+include "includes/db.php";
+include "includes/header.php";
+?>
 
 <?php
 

--- a/registration.php
+++ b/registration.php
@@ -1,4 +1,7 @@
 <?php
+
+session_start();
+
 include "includes/db.php";
 include "includes/header.php";
 ?>


### PR DESCRIPTION
Specific browsing for logged in users was failing on "Contact" and "Register" pages because there was no data in `$_SESSION`.

We can fix this by adding the `session_start()` function at the beginning of each page.

This PR is related to the issue #56 