### PR TITLE
Feature: Add link 'View Profile' in ad_navigation as dropdown-menu of 'Profile'

### DIFF
--- a/admin/includes/ad_navigation.php
+++ b/admin/includes/ad_navigation.php
@@ -77,7 +77,18 @@
                       <a href="comments.php"><i class="fa fa-fw fa-file"></i> Comments</a>
                   </li>
                   <li>
-                      <a href="profile.php"><i class="fa fa-fw fa-dashboard"></i> Profiles</a>
+                      <a href="javascript:;" data-toggle="collapse" data-target="#profile-dropdown">
+                          <i class="fa fa-fw fa-dashboard"></i>Profiles
+                          <i class="fa fa-fw fa-caret-down"></i>
+                      </a>
+                      <ul id="profile-dropdown" class="collapse">
+                          <li>
+                              <a href="profile.php">Update profile</a>
+                          </li>
+                          <li>
+                              <a href="/user.php?u_id=<?php echo $_SESSION['user_id']; ?>">View profile</a>
+                          </li>
+                      </ul>
                   </li>
               </ul>
           </div>
@@ -89,9 +100,9 @@
 
       <div class="preloader">
   <div class="box">
-  <div></div>  
-  <div></div>  
-  <div></div>  
+  <div></div>
+  <div></div>
+  <div></div>
   </div>
 
 </div>

--- a/user.php
+++ b/user.php
@@ -68,7 +68,11 @@
       </div>
   </div>
   <div class="profile-info col-md-9">
-
+      <div class="pull-right" style="margin-top: 1px; margin-right: 1px;">
+          <button type="button" class="btn btn-primary btn-sm" onclick="history.back()">
+              <i class="glyphicon glyphicon-chevron-left"></i> Go back
+          </button>
+      </div>
       <div class="panel">
           <div class="bio-graph-heading">
              <?php echo $user_info;?>
@@ -94,11 +98,6 @@
 
               </div>
           </div>
-      </div>
-      <div class="pull-right">
-          <button type="button" class="btn btn-primary btn-xs" onclick="history.back()">
-              <i class="fa fa-arrow-left"></i> Go back
-          </button>
       </div>
       <div>
       <div class="row " id="uposts">

--- a/user.php
+++ b/user.php
@@ -14,14 +14,14 @@
         <div class="row ">
 
             <!-- Blog Entries Column -->
-         
+
 
                 <?php
-             
+
                 if (isset($_GET['u_id'])) {
                     $link_user_id = $_GET['u_id'];
 
-           
+
 
                     $query = "SELECT * FROM users WHERE user_id=$link_user_id";
                     $select_all_users_query = mysqli_query($connection, $query);
@@ -45,7 +45,7 @@
                     }
                 ?>
 
-                      
+
 
                         <div class="container bootstrap snippets bootdey">
 <div class="row">
@@ -68,10 +68,10 @@
       </div>
   </div>
   <div class="profile-info col-md-9">
-    
+
       <div class="panel">
           <div class="bio-graph-heading">
-             <?php echo $user_info;?> 
+             <?php echo $user_info;?>
           </div>
           <div class="panel-body bio-graph-info">
               <h1>Bio Graph</h1>
@@ -91,18 +91,23 @@
                   <div class="bio-row">
                       <p><span>Email </span>:<?php echo $user_mail ?></p>
                   </div>
-              
+
               </div>
           </div>
       </div>
+      <div class="pull-right">
+          <button type="button" class="btn btn-primary btn-xs" onclick="history.back()">
+              <i class="fa fa-arrow-left"></i> Go back
+          </button>
+      </div>
       <div>
       <div class="row " id="uposts">
-<?php 
+<?php
  $link_user_id2 = $_GET['u_id'];
 
-           
 
-   
+
+
   $query = "SELECT * FROM posts WHERE author_id=$link_user_id2 AND post_status='published'";
                     $select_all_posts_query = mysqli_query($connection, $query);
 
@@ -110,7 +115,7 @@
                     while ($row = mysqli_fetch_assoc($select_all_posts_query)) {
                         $post_title = $row['post_title'];
                         $post_id = $row['post_id'];
-                     
+
                         $post_date = $row['post_date'];
                         $post_image = $row['post_image'];
                         $post_content = $row['post_content'];
@@ -122,7 +127,7 @@
                         $cat = mysqli_fetch_assoc($select_categories_id);
                         $post_category = $cat['cat_title'];?>
 
-          
+
               <div class="col-md-12">
                   <div class="panel">
                       <div class="panel-body">
@@ -165,8 +170,8 @@ text-align:left;"><?php echo $post_category; ?></i>
                       </div>
                   </div>
               </div>
-              
-     
+
+
 
 
 
@@ -222,7 +227,7 @@ text-align:left;"><?php echo $post_category; ?></i>
 
             </div>
 
-          
+
         </div>
         <!-- /.row -->
 


### PR DESCRIPTION
There's a page with the URL `/user.php?u_id=<user's id>`, but none of the menus from admin navigation pointed to this. So I changed the "Profile" menu to be a dropdown with the options "Update profile" (pointing to `admin/profile.php`) and "View profile" (pointing to the URL we're talking about).

This PR is related to issue #55 